### PR TITLE
issue-#12-JQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   },
   "homepage": "https://github.com/automatedb/WMD02-CHAT#readme",
   "dependencies": {
+    "bootstrap": "^4.0.0-alpha.6",
     "express": "^4.15.4",
-    "mongoose": "^4.11.7",
     "font-awesome": "^4.7.0",
-    "winston": "^2.3.1",
-    "bootstrap": "^4.0.0-alpha.6"
+    "jquery": "^3.2.1",
+    "mongoose": "^4.11.7",
+    "popper.js": "^1.12.3",
+    "winston": "^2.3.1"
   }
 }


### PR DESCRIPTION
Rajout de la bibliotheque Jquery
NPM requiert l'installation de Popper.js
Rajout de popper.js